### PR TITLE
Add FastAPI integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ You can download from the appstore if you use an iPhone, iPad or a Mac with Sili
 <a href="https://github.com/JideGuru/FlutterEbookApp">
         <img width="500" alt="Star History Chart" src="https://api.star-history.com/svg?repos=JideGuru/FlutterEbookApp&type=Date">
       </a>
+
+## FastAPI Backend Integration
+
+This project can interact with a FastAPI backend. The example backend used during development is [fastapi-realworld-example-app](https://github.com/nsidnev/fastapi-realworld-example-app).
+
+1. Clone the backend repository outside this project and install its dependencies.
+2. Run the server locally using `uvicorn app.main:app --reload`.
+3. Ensure the base URL in `lib/src/common/constants/api.dart` matches the server address (default is `http://localhost:8000`).
+4. Start the Flutter application. The new "My Books" section in Settings demonstrates fetching data from FastAPI.

--- a/lib/src/common/constants/api.dart
+++ b/lib/src/common/constants/api.dart
@@ -1,12 +1,17 @@
-const String baseURL = 'https://catalog.feedbooks.com';
-const String publicDomainURL = '/publicdomain/browse';
-const String popular = '$publicDomainURL/top.atom';
-const String recent = '$publicDomainURL/recent.atom';
-const String awards = '$publicDomainURL/awards.atom';
-const String noteworthy = '$publicDomainURL/homepage_selection.atom';
-const String shortStory = '$publicDomainURL/top.atom?cat=FBFIC029000';
-const String sciFi = '$publicDomainURL/top.atom?cat=FBFIC028000';
-const String actionAdventure = '$publicDomainURL/top.atom?cat=FBFIC002000';
-const String mystery = '$publicDomainURL/top.atom?cat=FBFIC022000';
-const String romance = '$publicDomainURL/top.atom?cat=FBFIC027000';
-const String horror = '$publicDomainURL/top.atom?cat=FBFIC015000';
+// Base URL for the FastAPI backend. Update this if the server location changes.
+const String baseURL = 'http://localhost:8000';
+
+// Endpoints served by the FastAPI application. These replace the previous
+// Feedbooks URLs and return JSON data instead of Atom feeds.
+const String popular = '/api/books/popular';
+const String recent = '/api/books/recent';
+
+// Additional category endpoints that can be implemented on the backend.
+const String awards = '/api/books/awards';
+const String noteworthy = '/api/books/noteworthy';
+const String shortStory = '/api/books/genre/short-story';
+const String sciFi = '/api/books/genre/science-fiction';
+const String actionAdventure = '/api/books/genre/action-adventure';
+const String mystery = '/api/books/genre/mystery';
+const String romance = '/api/books/genre/romance';
+const String horror = '/api/books/genre/horror';

--- a/lib/src/features/books/books.dart
+++ b/lib/src/features/books/books.dart
@@ -1,0 +1,3 @@
+export 'data/data.dart';
+export 'domain/book.dart';
+export 'presentation/presentation.dart';

--- a/lib/src/features/books/data/books_repository.dart
+++ b/lib/src/features/books/data/books_repository.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_ebook_app/src/common/constants/api.dart';
+import '../domain/book.dart';
+
+class BooksRepository {
+  final Dio httpClient;
+
+  const BooksRepository(this.httpClient);
+
+  Future<List<Book>> fetchBooks() async {
+    final response = await httpClient.get('/api/books');
+    final data = response.data as List<dynamic>;
+    return data
+        .map((e) => Book.fromJson(e as Map<String, dynamic>))
+        .toList();
+  }
+}

--- a/lib/src/features/books/data/data.dart
+++ b/lib/src/features/books/data/data.dart
@@ -1,0 +1,1 @@
+export 'books_repository.dart';

--- a/lib/src/features/books/domain/book.dart
+++ b/lib/src/features/books/domain/book.dart
@@ -1,0 +1,31 @@
+class Book {
+  final int id;
+  final String title;
+  final String description;
+  final String author;
+
+  Book({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.author,
+  });
+
+  factory Book.fromJson(Map<String, dynamic> json) {
+    return Book(
+      id: json['id'] as int,
+      title: json['title'] as String,
+      description: json['description'] as String? ?? '',
+      author: json['author'] as String? ?? '',
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'title': title,
+      'description': description,
+      'author': author,
+    };
+  }
+}

--- a/lib/src/features/books/presentation/books_provider.dart
+++ b/lib/src/features/books/presentation/books_provider.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_ebook_app/src/common/presentation/providers/dio_provider.dart';
+import '../data/books_repository.dart';
+import '../domain/book.dart';
+
+final booksRepositoryProvider = Provider<BooksRepository>((ref) {
+  final dio = ref.watch(dioProvider);
+  return BooksRepository(dio);
+});
+
+final booksListProvider = FutureProvider<List<Book>>((ref) async {
+  final repo = ref.watch(booksRepositoryProvider);
+  return repo.fetchBooks();
+});

--- a/lib/src/features/books/presentation/presentation.dart
+++ b/lib/src/features/books/presentation/presentation.dart
@@ -1,0 +1,2 @@
+export 'books_provider.dart';
+export 'ui/screens/books_screen.dart';

--- a/lib/src/features/books/presentation/ui/screens/books_screen.dart
+++ b/lib/src/features/books/presentation/ui/screens/books_screen.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../books_provider.dart';
+import '../../../domain/book.dart';
+
+class BooksScreen extends ConsumerWidget {
+  const BooksScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final booksAsync = ref.watch(booksListProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('Books')),
+      body: booksAsync.when(
+        data: (books) => ListView.builder(
+          itemCount: books.length,
+          itemBuilder: (_, index) {
+            final Book book = books[index];
+            return ListTile(
+              title: Text(book.title),
+              subtitle: Text(book.author),
+            );
+          },
+        ),
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, __) => Center(child: Text('Error: $e')),
+      ),
+    );
+  }
+}

--- a/lib/src/features/features.dart
+++ b/lib/src/features/features.dart
@@ -1,4 +1,5 @@
 export 'book_details/book_details.dart';
+export 'books/books.dart';
 export 'downloads/downloads.dart';
 export 'explore/explore.dart';
 export 'favorites/favourites.dart';

--- a/lib/src/features/settings/presentation/ui/screens/settings_screen_small.dart
+++ b/lib/src/features/settings/presentation/ui/screens/settings_screen_small.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_ebook_app/src/common/common.dart';
+import 'package:flutter_ebook_app/src/features/books/books.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -27,6 +28,11 @@ class _SettingsScreenSmallState extends State<SettingsScreenSmall> {
         'icon': Feather.download,
         'title': 'Downloads',
         'function': () => _pushPage(const DownloadsRoute()),
+      },
+      {
+        'icon': Feather.book,
+        'title': 'My Books',
+        'function': () => _pushBooksScreen(),
       },
       {
         'icon': Feather.moon,
@@ -89,6 +95,14 @@ class _SettingsScreenSmallState extends State<SettingsScreenSmall> {
             },
           ),
         ],
+      ),
+    );
+  }
+
+  void _pushBooksScreen() {
+    Navigator.of(context).push(
+      MaterialPageRoute(
+        builder: (_) => const BooksScreen(),
       ),
     );
   }


### PR DESCRIPTION
## Summary
- switch API constants to use a FastAPI backend
- document how to run the FastAPI server
- create new `books` feature with model, repository, provider and screen
- expose the new screen from Settings

## Testing
- `git status --short`