### PR TITLE
Fix plugin usage and clarify Java version

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You can download from the appstore if you use an iPhone, iPad or a Mac with Sili
 - Any Operating System (ie. MacOS X, Linux, Windows)
 - Any IDE with Flutter SDK installed (ie. IntelliJ, Android Studio, VSCode etc)
 - A little knowledge of Dart and Flutter
+- Use JDK 11 or JDK 17 (Gradle 7.5 does not work with Java 21)
+- Run builds using the provided Gradle wrapper (Gradle 7.5)
 
 ## ✨ Features
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,9 +21,11 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
 
 android {
     compileSdkVersion 33

--- a/packages/iridium/reader_widget/example/android/app/build.gradle
+++ b/packages/iridium/reader_widget/example/android/app/build.gradle
@@ -21,9 +21,11 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
 
 android {
     compileSdkVersion flutter.compileSdkVersion

--- a/packages/iridium/reader_widget/example/android/settings.gradle
+++ b/packages/iridium/reader_widget/example/android/settings.gradle
@@ -8,4 +8,7 @@ localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+
+plugins {
+    id 'dev.flutter.flutter-plugin-loader'
+}


### PR DESCRIPTION
## Summary
- use the new `plugins` block for the Flutter Gradle plugin
- adjust example Android build files to the same syntax
- remove old plugin loader usage
- document supported Java version and wrapper usage in the README

## Testing
- `flutter --version` *(fails: command not found)*
- `./gradlew --version` *(fails: no such file or directory)*