### PR TITLE
Fix Flutter plugin loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ You can download from the appstore if you use an iPhone, iPad or a Mac with Sili
 - Any Operating System (ie. MacOS X, Linux, Windows)
 - Any IDE with Flutter SDK installed (ie. IntelliJ, Android Studio, VSCode etc)
 - A little knowledge of Dart and Flutter
+- Use JDK 11 or JDK 17 (Gradle 7.5 does not work with Java 21)
+- Run builds using the provided Gradle wrapper (Gradle 7.5)
 
 ## ✨ Features
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -21,9 +21,11 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
 
 android {
     compileSdkVersion 33

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,15 +1,5 @@
 include ':app'
 
-def flutterProjectRoot = rootProject.projectDir.parentFile.toPath()
-
-def plugins = new Properties()
-def pluginsFile = new File(flutterProjectRoot.toFile(), '.flutter-plugins')
-if (pluginsFile.exists()) {
-    pluginsFile.withReader('UTF-8') { reader -> plugins.load(reader) }
-}
-
-plugins.each { name, path ->
-    def pluginDirectory = flutterProjectRoot.resolve(path).resolve('android').toFile()
-    include ":$name"
-    project(":$name").projectDir = pluginDirectory
+plugins {
+    id 'dev.flutter.flutter-plugin-loader'
 }

--- a/packages/iridium/reader_widget/example/android/app/build.gradle
+++ b/packages/iridium/reader_widget/example/android/app/build.gradle
@@ -21,9 +21,11 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-apply plugin: 'com.android.application'
-apply plugin: 'kotlin-android'
-apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
 
 android {
     compileSdkVersion flutter.compileSdkVersion

--- a/packages/iridium/reader_widget/example/android/settings.gradle
+++ b/packages/iridium/reader_widget/example/android/settings.gradle
@@ -8,4 +8,7 @@ localPropertiesFile.withReader("UTF-8") { reader -> properties.load(reader) }
 
 def flutterSdkPath = properties.getProperty("flutter.sdk")
 assert flutterSdkPath != null, "flutter.sdk not set in local.properties"
-apply from: "$flutterSdkPath/packages/flutter_tools/gradle/app_plugin_loader.gradle"
+
+plugins {
+    id 'dev.flutter.flutter-plugin-loader'
+}


### PR DESCRIPTION
## Summary
- use plugin loader plugin in root settings.gradle
- switch to plugin block for android Gradle plugin
- document JDK and Gradle requirements in README

## Testing
- `flutter --version` *(fails: command not found)*
- `./gradlew --version` *(fails: no such file or directory)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.