### PR TITLE
Fix Flutter plugin loader in Android settings

### DIFF
--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,25 @@
-include ':app'
+pluginManagement {
+    def localPropertiesFile = new File(settingsDir, 'local.properties')
+    def properties = new Properties()
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.withReader('UTF-8') { reader -> properties.load(reader) }
+    }
+    def flutterSdkPath = properties.getProperty('flutter.sdk')
+    if (flutterSdkPath == null) {
+        throw new GradleException('flutter.sdk not set in local.properties')
+    }
+
+    includeBuild("${flutterSdkPath}/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
 plugins {
     id 'dev.flutter.flutter-plugin-loader'
 }
+
+include ':app'


### PR DESCRIPTION
## Summary
- load Flutter Gradle plugin through pluginManagement in android/settings.gradle

## Testing
- `dart --version` *(fails: command not found)*