### PR TITLE
Fix plugin order in build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,9 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+    id 'dev.flutter.flutter-gradle-plugin'
+}
+
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -21,11 +27,6 @@ if (flutterVersionName == null) {
     flutterVersionName = '1.0'
 }
 
-plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
-    id 'dev.flutter.flutter-gradle-plugin'
-}
 
 android {
     compileSdkVersion 33

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,5 +1,25 @@
-include ':app'
+pluginManagement {
+    def localPropertiesFile = new File(settingsDir, 'local.properties')
+    def properties = new Properties()
+    if (localPropertiesFile.exists()) {
+        localPropertiesFile.withReader('UTF-8') { reader -> properties.load(reader) }
+    }
+    def flutterSdkPath = properties.getProperty('flutter.sdk')
+    if (flutterSdkPath == null) {
+        throw new GradleException('flutter.sdk not set in local.properties')
+    }
+
+    includeBuild("${flutterSdkPath}/packages/flutter_tools/gradle")
+
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
 
 plugins {
     id 'dev.flutter.flutter-plugin-loader'
 }
+
+include ':app'


### PR DESCRIPTION
## Summary
- move the Gradle `plugins` block to the start of `android/app/build.gradle`
- keep Flutter plugin management in `android/settings.gradle`

## Testing
- `dart --version` *(fails: command not found)*