### PR TITLE
Fix README conflict and remove ephemeral files

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ You can download from the appstore if you use an iPhone, iPad or a Mac with Sili
 - Any Operating System (ie. MacOS X, Linux, Windows)
 - Any IDE with Flutter SDK installed (ie. IntelliJ, Android Studio, VSCode etc)
 - A little knowledge of Dart and Flutter
-- Use JDK 11 or JDK 17 (Gradle 7.5 does not work with Java 21)
-- Run builds using the provided Gradle wrapper (Gradle 7.5)
+- Use JDK 17 (推荐与本仓库的 Gradle 8.2 搭配使用)
+- 使用仓库自带的 Gradle wrapper (Gradle 8.2)
 
 ## ✨ Features
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -30,3 +30,4 @@ Runner/GeneratedPluginRegistrant.*
 !default.mode2v3
 !default.pbxuser
 !default.perspectivev3
+Flutter/ephemeral/


### PR DESCRIPTION
## Summary
- ignore iOS Flutter/ephemeral directory and remove previously committed files
- restore `pubspec.lock` to match master
- keep Gradle wrapper at 8.2 and README instructions for JDK 17

## Testing
- `gradle -v`
