### PR TITLE
Fix GradleException removal

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,7 +4,6 @@ plugins {
     id 'dev.flutter.flutter-gradle-plugin'
 }
 
-import org.gradle.api.GradleException
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,3 @@
-import org.gradle.api.GradleException
 
 pluginManagement {
     def localPropertiesFile = new File(settingsDir, 'local.properties')

--- a/packages/iridium/reader_widget/example/android/app/build.gradle
+++ b/packages/iridium/reader_widget/example/android/app/build.gradle
@@ -1,4 +1,3 @@
-import org.gradle.api.GradleException
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
@@ -8,7 +7,6 @@ if (localPropertiesFile.exists()) {
     }
 }
 
-import org.gradle.api.GradleException
 
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {


### PR DESCRIPTION
## Summary
- remove explicit GradleException imports so Gradle 8 builds succeed

## Testing
- `dart --version` *(fails: command not found)*
