### PR TITLE
Replace deprecated GradleException usage

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'dev.flutter.flutter-gradle-plugin'
 }
 
+import java.io.FileNotFoundException
+
 
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
@@ -15,7 +17,7 @@ if (localPropertiesFile.exists()) {
 
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+    throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,4 +1,6 @@
 
+import java.io.FileNotFoundException
+
 pluginManagement {
     def localPropertiesFile = new File(settingsDir, 'local.properties')
     def properties = new Properties()
@@ -7,7 +9,7 @@ pluginManagement {
     }
     def flutterSdkPath = properties.getProperty('flutter.sdk')
     if (flutterSdkPath == null) {
-        throw new GradleException('flutter.sdk not set in local.properties')
+        throw new FileNotFoundException('flutter.sdk not set in local.properties')
     }
 
     includeBuild("${flutterSdkPath}/packages/flutter_tools/gradle")

--- a/packages/iridium/reader_widget/example/android/app/build.gradle
+++ b/packages/iridium/reader_widget/example/android/app/build.gradle
@@ -1,4 +1,5 @@
 
+import java.io.FileNotFoundException
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {
@@ -10,7 +11,7 @@ if (localPropertiesFile.exists()) {
 
 def flutterRoot = localProperties.getProperty('flutter.sdk')
 if (flutterRoot == null) {
-    throw new GradleException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
+    throw new FileNotFoundException("Flutter SDK not found. Define location with flutter.sdk in the local.properties file.")
 }
 
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')


### PR DESCRIPTION
## Summary
- replace `GradleException` with `FileNotFoundException` in Android build scripts

## Testing
- `flutter --version` *(fails: command not found)*
- `./gradlew -version` *(fails: no such file or directory)*