### PR TITLE
Fix build errors on Windows

### DIFF
--- a/packages/iridium/components/navigator/lib/src/epub/selection/annotation_popup.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/selection/annotation_popup.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectionListener;
 import 'package:mno_navigator/epub.dart';
 import 'package:mno_navigator/publication.dart';
 

--- a/packages/iridium/components/navigator/lib/src/epub/selection/highlight_popup.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/selection/highlight_popup.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectionListener;
 import 'package:mno_navigator/epub.dart';
 import 'package:mno_navigator/publication.dart';
 import 'package:mno_navigator/src/epub/selection/selection_popup.dart';

--- a/packages/iridium/components/navigator/lib/src/epub/selection/new_selection_popup.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/selection/new_selection_popup.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectionListener;
 import 'package:mno_navigator/epub.dart';
 import 'package:mno_navigator/publication.dart';
 import 'package:mno_navigator/src/epub/selection/highlight_popup.dart';

--- a/packages/iridium/components/navigator/lib/src/epub/selection/selection_listener_factory.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/selection/selection_listener_factory.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/widgets.dart' hide SelectionListener;
 import 'package:mno_navigator/epub.dart';
 import 'package:mno_navigator/src/publication/reader_context.dart';
 

--- a/packages/iridium/components/navigator/lib/src/epub/selection/selection_popup.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/selection/selection_popup.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart' hide SelectionListener;
+import 'package:flutter/widgets.dart' hide SelectionListener;
 import 'package:mno_navigator/epub.dart';
 import 'package:mno_navigator/publication.dart';
 

--- a/packages/iridium/components/navigator/lib/src/epub/selection/simple_selection_listener.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/selection/simple_selection_listener.dart
@@ -1,5 +1,5 @@
 import 'package:dfunc/dfunc.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectionListener;
 import 'package:mno_navigator/epub.dart';
 import 'package:mno_navigator/publication.dart';
 import 'package:mno_navigator/src/epub/selection/annotation_popup.dart';

--- a/packages/iridium/components/navigator/lib/src/epub/widget/webview_screen_state.dart
+++ b/packages/iridium/components/navigator/lib/src/epub/widget/webview_screen_state.dart
@@ -9,7 +9,7 @@ import 'package:dfunc/dfunc.dart';
 import 'package:fimber/fimber.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart' hide Decoration;
+import 'package:flutter/material.dart' hide Decoration, SelectionListener;
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mno_webview/webview.dart';
 import 'package:mno_navigator/epub.dart';

--- a/packages/iridium/components/shared/lib/src/zip/lazy_zip_decoder.dart
+++ b/packages/iridium/components/shared/lib/src/zip/lazy_zip_decoder.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:archive/archive.dart' as a;
+import 'package:mno_shared/src/zip/zip_header.dart';
 import 'package:mno_shared/src/zip/file_buffer.dart';
 import 'package:mno_shared/src/zip/lazy_archive.dart';
 import 'package:mno_shared/src/zip/lazy_archive_file.dart';
@@ -23,7 +24,7 @@ class LazyZipDecoder {
 
         // The attributes are stored in base 8
         final mode = zfh.externalFileAttributes;
-        final compress = zf.compressionMethod != a.ZipFile.STORE;
+        final compress = zf.compressionMethod != ZipHeader.stored;
 
         LazyArchiveFile file = LazyArchiveFile(
             zfh, zf.filename, zf.uncompressedSize, zf.compressionMethod);


### PR DESCRIPTION
## Summary
- hide Flutter's SelectionListener in imports to avoid conflicts
- use ZipHeader.stored constant in LazyZipDecoder

## Testing
- `dart format` *(fails: `dart: command not found`)*