### PR TITLE
Fix example plugin Gradle config

### DIFF
--- a/packages/iridium/reader_widget/example/android/build.gradle
+++ b/packages/iridium/reader_widget/example/android/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.2.2'
+        classpath 'com.android.tools.build:gradle:8.2.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/packages/iridium/reader_widget/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/iridium/reader_widget/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip


### PR DESCRIPTION
## Summary
- update Iridium reader example to Android Gradle Plugin 8.2
- bump Kotlin to 1.9.0
- use Gradle 8.2 wrapper

## Testing
- `git log -1 --stat`